### PR TITLE
Include KEM-type algorithms in early key shares

### DIFF
--- a/tls/src/main/java/org/bouncycastle/tls/AbstractTlsClient.java
+++ b/tls/src/main/java/org/bouncycastle/tls/AbstractTlsClient.java
@@ -420,72 +420,40 @@ public abstract class AbstractTlsClient
             return null;
         }
 
-        Integer firstKemNamedGroup = null;
-        int firstKemNamedGroupIndex = -1;
+        Vector<Integer> earlyKeyShareGroups = new Vector<>(1);
 
-        for (int i = 0; i < supportedGroups.size(); i++)
+        for (Object groupObj : supportedGroups)
         {
-            Integer group = (Integer) supportedGroups.elementAt(i);
+            Integer group = (Integer) groupObj;
             if (NamedGroup.refersToASpecificKem(group))
             {
-                firstKemNamedGroup = group;
-                firstKemNamedGroupIndex = i;
+                earlyKeyShareGroups.addElement(group);
                 break;
             }
         }
 
-        Integer firstNonKemNamedGroup = null;
-        int firstNonKemNamedGroupIndex = -1;
-
         if (supportedGroups.contains(Integers.valueOf(NamedGroup.x25519)))
         {
-            firstNonKemNamedGroup = Integers.valueOf(NamedGroup.x25519);
-            firstNonKemNamedGroupIndex = supportedGroups.indexOf(firstNonKemNamedGroup);
+            earlyKeyShareGroups.addElement(Integers.valueOf(NamedGroup.x25519));
         }
         else if (supportedGroups.contains(Integers.valueOf(NamedGroup.secp256r1)))
         {
-            firstNonKemNamedGroup = Integers.valueOf(NamedGroup.secp256r1);
-            firstNonKemNamedGroupIndex = supportedGroups.indexOf(firstNonKemNamedGroup);
+            earlyKeyShareGroups.addElement(Integers.valueOf(NamedGroup.secp256r1));
         }
         else
         {
-            for (int i = 0; i < supportedGroups.size(); i++)
+            for (Object groupObj : supportedGroups)
             {
-                Integer group = (Integer) supportedGroups.elementAt(i);
+                Integer group = (Integer) groupObj;
                 if (!NamedGroup.refersToASpecificKem(group))
                 {
-                    firstNonKemNamedGroup = group;
-                    firstNonKemNamedGroupIndex = i;
+                    earlyKeyShareGroups.addElement(group);
                     break;
                 }
             }
         }
 
-        Vector<Integer> earlyKeyShareGroups = new Vector<>();
-
-        if (firstKemNamedGroupIndex != -1 && firstNonKemNamedGroupIndex != -1)
-        {
-            if (firstKemNamedGroupIndex < firstNonKemNamedGroupIndex)
-            {
-                earlyKeyShareGroups.add(firstKemNamedGroup);
-                earlyKeyShareGroups.add(firstNonKemNamedGroup);
-            }
-            else
-            {
-                earlyKeyShareGroups.add(firstNonKemNamedGroup);
-                earlyKeyShareGroups.add(firstKemNamedGroup);
-            }
-        }
-        else if (firstKemNamedGroup != null)
-        {
-            earlyKeyShareGroups.add(firstKemNamedGroup);
-        }
-        else if (firstNonKemNamedGroup != null)
-        {
-            earlyKeyShareGroups.add(firstNonKemNamedGroup);
-        }
-
-        return TlsUtils.vectorFromArray(earlyKeyShareGroups.toArray());
+        return earlyKeyShareGroups;
     }
 
     public boolean shouldUseCompatibilityMode()

--- a/tls/src/main/java/org/bouncycastle/tls/AbstractTlsClient.java
+++ b/tls/src/main/java/org/bouncycastle/tls/AbstractTlsClient.java
@@ -419,15 +419,73 @@ public abstract class AbstractTlsClient
         {
             return null;
         }
+
+        Integer firstKemNamedGroup = null;
+        int firstKemNamedGroupIndex = -1;
+
+        for (int i = 0; i < supportedGroups.size(); i++)
+        {
+            Integer group = (Integer) supportedGroups.elementAt(i);
+            if (NamedGroup.refersToASpecificKem(group))
+            {
+                firstKemNamedGroup = group;
+                firstKemNamedGroupIndex = i;
+                break;
+            }
+        }
+
+        Integer firstNonKemNamedGroup = null;
+        int firstNonKemNamedGroupIndex = -1;
+
         if (supportedGroups.contains(Integers.valueOf(NamedGroup.x25519)))
         {
-            return TlsUtils.vectorOfOne(Integers.valueOf(NamedGroup.x25519));
+            firstNonKemNamedGroup = Integers.valueOf(NamedGroup.x25519);
+            firstNonKemNamedGroupIndex = supportedGroups.indexOf(firstNonKemNamedGroup);
         }
-        if (supportedGroups.contains(Integers.valueOf(NamedGroup.secp256r1)))
+        else if (supportedGroups.contains(Integers.valueOf(NamedGroup.secp256r1)))
         {
-            return TlsUtils.vectorOfOne(Integers.valueOf(NamedGroup.secp256r1));
+            firstNonKemNamedGroup = Integers.valueOf(NamedGroup.secp256r1);
+            firstNonKemNamedGroupIndex = supportedGroups.indexOf(firstNonKemNamedGroup);
         }
-        return TlsUtils.vectorOfOne(supportedGroups.elementAt(0));
+        else
+        {
+            for (int i = 0; i < supportedGroups.size(); i++)
+            {
+                Integer group = (Integer) supportedGroups.elementAt(i);
+                if (!NamedGroup.refersToASpecificKem(group))
+                {
+                    firstNonKemNamedGroup = group;
+                    firstNonKemNamedGroupIndex = i;
+                    break;
+                }
+            }
+        }
+
+        Vector<Integer> earlyKeyShareGroups = new Vector<>();
+
+        if (firstKemNamedGroupIndex != -1 && firstNonKemNamedGroupIndex != -1)
+        {
+            if (firstKemNamedGroupIndex < firstNonKemNamedGroupIndex)
+            {
+                earlyKeyShareGroups.add(firstKemNamedGroup);
+                earlyKeyShareGroups.add(firstNonKemNamedGroup);
+            }
+            else
+            {
+                earlyKeyShareGroups.add(firstNonKemNamedGroup);
+                earlyKeyShareGroups.add(firstKemNamedGroup);
+            }
+        }
+        else if (firstKemNamedGroup != null)
+        {
+            earlyKeyShareGroups.add(firstKemNamedGroup);
+        }
+        else if (firstNonKemNamedGroup != null)
+        {
+            earlyKeyShareGroups.add(firstNonKemNamedGroup);
+        }
+
+        return TlsUtils.vectorFromArray(earlyKeyShareGroups.toArray());
     }
 
     public boolean shouldUseCompatibilityMode()

--- a/tls/src/main/java/org/bouncycastle/tls/TlsUtils.java
+++ b/tls/src/main/java/org/bouncycastle/tls/TlsUtils.java
@@ -2707,6 +2707,16 @@ public class TlsUtils
         return v;
     }
 
+    public static Vector vectorFromArray(Object[] array)
+    {
+        Vector v = new Vector(array.length);
+        for (Object obj: array)
+        {
+            v.addElement(obj);
+        }
+        return v;
+    }
+
     public static int getCipherType(int cipherSuite)
     {
         int encryptionAlgorithm = getEncryptionAlgorithm(cipherSuite);

--- a/tls/src/main/java/org/bouncycastle/tls/TlsUtils.java
+++ b/tls/src/main/java/org/bouncycastle/tls/TlsUtils.java
@@ -2707,16 +2707,6 @@ public class TlsUtils
         return v;
     }
 
-    public static Vector vectorFromArray(Object[] array)
-    {
-        Vector v = new Vector(array.length);
-        for (Object obj: array)
-        {
-            v.addElement(obj);
-        }
-        return v;
-    }
-
     public static int getCipherType(int cipherSuite)
     {
         int encryptionAlgorithm = getEncryptionAlgorithm(cipherSuite);


### PR DESCRIPTION
In the current implementation, if either the `x25519` or `secp256r1` algorithms are present in the list of named groups, one of them is used for early key shares, regardless of the presence of other algorithms. However, with the growing adoption of post-quantum cryptography, it is increasingly important to include post-quantum secure algorithms (i.e., KEM-based algorithms) in the early key shares.

[Section 4.2.8 in the RFC 8446](https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.8) mentions the following:

> Clients can offer as many KeyShareEntry values as the number of supported groups it is offering, each representing a single set of key exchange parameters.

This means it is valid for clients to include multiple `KeyShareEntry` values corresponding to different named groups.

#### Updated Logic

The updated implementation modifies the selection logic for early key shares as follows:

- **If no KEM-type algorithms are present** in the list of named groups:
  - If `x25519` or `secp256r1` is present, it is selected (in that order of preference).
  - Otherwise, the first algorithm in the list is used.

- **If one or more KEM-type algorithms are present**:
  - The first KEM-type algorithm from the list is selected.
  - Additionally, the non-KEM algorithm is chosen using the following logic.
    - If `x25519` or `secp256r1` is present, it is selected (in that order of preference).
    - Otherwise, the first algorithm in the list is used.

This change ensures early key share negotiation includes support for post-quantum algorithms while maintaining backward compatibility with existing logic.